### PR TITLE
Fix conditional for Linux report templating

### DIFF
--- a/roles/build_report_linux/templates/report.j2
+++ b/roles/build_report_linux/templates/report.j2
@@ -81,10 +81,10 @@ collapsible: true
         <tr>
             <td class="summary_info">
               <div id="hostname">
-                <p class="hostname"> 
+                <p class="hostname">
                   <img class="router_image" src="server.png"> {{ hostvars[linux_host]['inventory_hostname'].split('.')[0] }}</p>
                 </div>
-{% if detailedreport == 'True' %}
+{% if detailedreport %}
 {% include 'packages.j2' %}
 {% include 'services.j2' %}
 {% endif %}


### PR DESCRIPTION
Default var references `true` as a boolean, however the template is using `"true"` as a string causing the condition to never be met.

https://github.com/shadowman-lab/shadowman.reports/blob/47fcf11ea6ed4a87e2093150918e21f54f2a78c3/roles/build_report_linux/defaults/main.yml#L2

Setting the condition to evaluate as a boolean instead of string.
